### PR TITLE
IUFC-615 : Dans le récap' des admissions, la colonne email affiche le…

### DIFF
--- a/templates/admissions.html
+++ b/templates/admissions.html
@@ -156,7 +156,7 @@
                             </a>
                             </td>
                             <td>{{ admission.person_information.person.first_name | default_if_none:'-'}}</td>
-                            <td>{{ admission.email | default_if_none:'' }}</td>
+                            <td>{{ admission.person_information.person.email | default_if_none:'' }}</td>
                             <td title="{{admission.formation.title}}">{{ admission.formation_display }}</td>
 
                             <td>{{ admission.formation.registration_required|yesno|title}}</td>


### PR DESCRIPTION
… champ admission.email (= adresse email additionnelle pas toujours remplie)

A la place mettre continuing_education_person.person.email (qui est toujours rempli)