### PR TITLE
IUFC-699 Fix participant email usages

### DIFF
--- a/templates/admissions.html
+++ b/templates/admissions.html
@@ -152,7 +152,7 @@
                             </a>
                             </td>
                             <td>{{ admission.person_information.person.first_name | default_if_none:'-'}}</td>
-                            <td>{{ admission.person_information.person.email | default_if_none:'' }}</td>
+                            <td>{{ admission.email | default_if_none:'' }}</td>
                             <td title="{{admission.formation.title}}">{{ admission.formation_display }}</td>
 
                             <td>{{ admission.formation.registration_required|yesno|title}}</td>

--- a/templates/registrations.html
+++ b/templates/registrations.html
@@ -150,7 +150,7 @@
                                 </a>
                             </td>
                             <td>{{ admission.person_information.person.first_name | default_if_none:'-' }}</td>
-                            <td>{{ admission.person_information.person.email | default_if_none:'-' }}</td>
+                            <td>{{ admission.email | default_if_none:'-' }}</td>
                             <td>{{ admission.formation }}</td>
                             <td>{{ admission.academic_year | default_if_none:'' }}</td>
                             <td title="{{ admission.faculty.title }}">{{ admission.get_faculty | default_if_none:'' }}</td>

--- a/tests/api/views/test_admission.py
+++ b/tests/api/views/test_admission.py
@@ -373,9 +373,10 @@ class AdmissionDetailUpdateTestCase(APITestCase):
             mock_call_args_participant_notification.get('template_references').get('html'),
             'iufc_participant_admission_submitted_html'
         )
-        self.assertEqual(
-            mock_call_args_participant_notification.get('receivers')[0].get('receiver_email'),
-            self.admission.person_information.person.email
+        receivers = mock_call_args_participant_notification.get('receivers')
+        self.assertCountEqual(
+            [receiver.get('receiver_email') for receiver in receivers],
+            [self.admission.email, self.admission.person_information.person.email]
         )
         self.assertEqual(
             mock_call_args_participant_notification.get('connected_user'),


### PR DESCRIPTION
- Send notif emails to both addresses if 2 available (in admission and person objects)
- Display admission.email address in admissions/registrations list
- Fix related tests