### PR TITLE
IUFC-743 : Limitation du nombre de caractères lors de l'encodage nom/…

### DIFF
--- a/business/registration_queue.py
+++ b/business/registration_queue.py
@@ -6,7 +6,7 @@
 #    The core business involves the administration of students, teachers,
 #    courses, programs and so on.
 #
-#    Copyright (C) 2015-2019 Université catholique de Louvain (http://www.uclouvain.be)
+#    Copyright (C) 2015-2022 Université catholique de Louvain (http://www.uclouvain.be)
 #
 #    This program is free software: you can redistribute it and/or modify
 #    it under the terms of the GNU General Public License as published by
@@ -44,14 +44,17 @@ from continuing_education.views.common import save_and_create_revision, get_revi
     UCL_REGISTRATION_REGISTERED
 from osis_common.queue.queue_sender import send_message
 
+MAX_LENGTH_FOR_LAST_NAME_FIELD_IN_EPC = 40
+MAX_LENGTH_FOR_FIRST_NAME_FIELD_IN_EPC = 20
+
 logger = logging.getLogger(settings.DEFAULT_LOGGER)
 
 
 def get_json_for_epc(admission):
     addresses_are_different = admission.address != admission.residence_address
     return {
-        'name': admission.person_information.person.last_name,
-        'first_name': admission.person_information.person.first_name,
+        'name': admission.person_information.person.last_name[0:MAX_LENGTH_FOR_LAST_NAME_FIELD_IN_EPC],
+        'first_name': admission.person_information.person.first_name[0:MAX_LENGTH_FOR_FIRST_NAME_FIELD_IN_EPC],
         'birth_date': admission.person_information.birth_date.strftime("%d/%m/%Y"),
         'birth_location': admission.person_information.birth_location,
         'birth_country_iso_code': admission.person_information.birth_country.iso_code,

--- a/forms/person.py
+++ b/forms/person.py
@@ -24,6 +24,7 @@
 #
 ##############################################################################
 from django import forms
+from django.core.exceptions import ValidationError
 from django.db.models.fields import BLANK_CHOICE_DASH
 from django.forms import ModelForm
 from django.utils.translation import gettext_lazy as _
@@ -44,8 +45,33 @@ IUFC_GENDER_CHOICES = (
     (MALE, _('Male'))
 )
 
+HELP_MSG_FIRST_LETTER_UPPERCASE = _("Only the first letter uppercase.")
+
+
+def validate_no_all_uppercase_characters(value):
+    if value.isupper():
+        raise ValidationError(
+            _("Last name and first name can't be encoded only in capital letters")
+        )
+
 
 class PersonForm(ModelForm):
+    first_name = forms.CharField(
+        required=True,
+        label=_("First name"),
+        help_text=HELP_MSG_FIRST_LETTER_UPPERCASE,
+        max_length=20,
+        validators=[validate_no_all_uppercase_characters]
+    )
+
+    last_name = forms.CharField(
+        required=True,
+        label=_("Last name"),
+        help_text=HELP_MSG_FIRST_LETTER_UPPERCASE,
+        max_length=40,
+        validators=[validate_no_all_uppercase_characters]
+    )
+
     gender = forms.ChoiceField(
         choices=IUFC_GENDER_CHOICES,
         required=False

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-17 10:09+0100\n"
+"POT-Creation-Date: 2022-02-24 09:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -629,6 +629,9 @@ msgid "Last modifications"
 msgstr ""
 
 msgid "Last name"
+msgstr ""
+
+msgid "Last name and first name can't be encoded only in capital letters"
 msgstr ""
 
 msgid "Last update"

--- a/locale/fr_BE/LC_MESSAGES/django.po
+++ b/locale/fr_BE/LC_MESSAGES/django.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-17 10:09+0100\n"
+"POT-Creation-Date: 2022-02-24 09:22+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -665,6 +665,9 @@ msgstr "Dernières modifications"
 
 msgid "Last name"
 msgstr "Nom"
+
+msgid "Last name and first name can't be encoded only in capital letters"
+msgstr "Les nom/prénom ne peuvent pas être encodés uniquement en lettres majuscules"
 
 msgid "Last update"
 msgstr "Dernière modification"


### PR DESCRIPTION
…prénom + validation pas tout en majuscules + tronquer si besoin lors de l'envoi dans EPC